### PR TITLE
Add a quickstart API and readme explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ resources:
 kubectl get claim,composite,managed
 ```
 
+Additionally, you can render out the tree of resources, starting from the claim:
+
+```console
+crossplane beta trace mockdatabase.quickstart.crossplane.io/database1
+
+NAME                                SYNCED   READY   STATUS
+MockDatabase/database1 (default)    True     True    Available
+└─ XMockDatabase/database1-v9l9t    True     True    Available
+   └─ NopResource/database1-v9l9t   True     True
+```
+
 To delete the provisioned resources, delete the claims:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -1,1 +1,124 @@
 # configuration-quickstart
+
+An introductory example to Crossplane and Compositions using provider-nop. This enables provisioning of several different fake resource types.
+
+This repository contains a reference configuration for [Crossplane](https://crossplane.io). This configuration uses [provider-nop](https://github.com/crossplane-contrib/provider-nop), a Crossplane provider that simulates the creation of external resources.
+
+## Overview
+
+The configuration offers an APIs for setting up a mock database resource. This configuration also demonstrates the power of Crossplane to build abstractions called `compositions`, which assemble multiple basic resources into a more complex resource.
+
+Learn more about Composite Resources in the [Crossplane
+Docs](https://docs.crossplane.io/latest/concepts/compositions/).
+
+```mermaid
+graph LR;
+    MyApp(My App)---MyDatabase(XRC: database1);
+    MyDatabase---XRD1(XRD: XMockDatabase);
+		subgraph Configuration;
+	    XRD1---Composition(XMockDatabase composition);
+		end
+		subgraph Provider
+	    Composition---MockDatabse.MRs(MRs: NopResource);
+		end
+
+style MyApp color:#000,fill:#e6e6e6,stroke:#000,stroke-width:2px
+style MyDatabase color:#000,fill:#D68A82,stroke:#000,stroke-width:2px
+style Configuration fill:#f1d16d,opacity:0.3
+style Provider fill:#81CABB,opacity:0.3
+style XRD1 color:#000,fill:#f1d16d,stroke:#000,stroke-width:2px,stroke-dasharray: 5 5
+style Composition color:#000,fill:#f1d16d,stroke:#000,stroke-width:2px
+
+style MockDatabse.MRs color:#000,fill:#81CABB,stroke:#000,stroke-width:2px
+```
+
+## Quickstart
+
+### Prerequisites
+
+Before you can install the Configuration, you should install the `crossplane` CLI. This is a utility that makes following this quickstart guide easier. Everything described here can also be done in a declarative approach - which we highly recommend for any production type use-case.
+<!-- TODO enhance this guide: Getting ready for Gitops -->
+
+To install `crossplane` run this install script:
+```console
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+```
+See [crossplane CLI docs](https://docs.crossplane.io/latest/cli/#installing-the-cli) for additional information.
+
+You need a running Crossplane control plane to install the Configuration into.
+Ensure that your kubectl context points to the correct Kubernetes cluster or
+create a new [kind](https://kind.sigs.k8s.io) cluster:
+
+```console
+kind create cluster
+```
+
+Enable the Crossplane Helm Chart repository:
+
+```console
+helm repo add \
+crossplane-stable https://charts.crossplane.io/stable
+helm repo update
+```
+
+Install the Crossplane components using helm install:
+
+```console
+helm install crossplane \
+crossplane-stable/crossplane \
+--namespace crossplane-system \
+--create-namespace
+```
+
+### Install the Quickstart configuration
+
+Now you can install this configuration. It's packaged as a [Crossplane
+configuration package](https://docs.crossplane.io/latest/concepts/packages/)
+so there is a single command to install it:
+
+```console
+crossplane xpkg install xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
+```
+
+Validate the install by inspecting the provider and configuration packages:
+```console
+kubectl get providers,providerrevision
+
+kubectl get configurations,configurationrevisions
+```
+
+## Using the Quickstart configuration
+
+🎉 Congratulations. You have just installed your first Crossplane-powered platform.
+
+You can now use the control plane to request resources which will simulate getting provisioned in an external cloud service. You do this by creating "claims" against the APIs available on your control palne. Following the example below, create the claims directly:
+
+Create a mock database:
+```console
+kubectl apply -f examples/XMockDatabase/example.yaml
+```
+
+You can verify the status by inspecting the claims, composites and managed
+resources:
+
+```console
+kubectl get claim,composite,managed
+```
+
+To delete the provisioned resources, delete the claims:
+
+```console
+kubectl delete -f examples/XMockDatabase/example.yaml
+```
+
+To uninstall the package and all dependencies:
+
+```console
+kubectl delete configurations.pkg.crossplane.io configuration-quickstart
+```
+
+## Questions?
+
+For any questions, thoughts and comments don't hesitate to [reach
+out](https://www.upbound.io/contact) or drop by
+[slack.crossplane.io](https://slack.crossplane.io), and introduce yourself.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,5 @@ kubectl delete configurations.pkg.crossplane.io configuration-quickstart
 
 ## Questions?
 
-For any questions, thoughts and comments don't hesitate to [reach
-out](https://www.upbound.io/contact) or drop by
-[slack.crossplane.io](https://slack.crossplane.io), and introduce yourself.
+For any questions, thoughts and comments [get involved](https://github.com/crossplane/crossplane?tab=readme-ov-file#get-involved) in the Crossplane community or drop by
+[slack.crossplane.io](https://slack.crossplane.io) and introduce yourself.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ configuration package](https://docs.crossplane.io/latest/concepts/packages/)
 so there is a single command to install it:
 
 ```console
-crossplane xpkg install xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
+crossplane xpkg install configuration xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
 ```
 
 Validate the install by inspecting the provider and configuration packages:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # configuration-quickstart
 
-An introductory example to Crossplane and Compositions using provider-nop. This enables provisioning of several different fake resource types.
+An introductory example to Crossplane and Compositions using provider-nop. This enables provisioning of several different fake resource types for testing and educational purposes.
 
 This repository contains a reference configuration for [Crossplane](https://crossplane.io). This configuration uses [provider-nop](https://github.com/crossplane-contrib/provider-nop), a Crossplane provider that simulates the creation of external resources.
 
 ## Overview
 
-The configuration offers an APIs for setting up a mock database resource. This configuration also demonstrates the power of Crossplane to build abstractions called `compositions`, which assemble multiple basic resources into a more complex resource.
+The configuration offers an API for setting up a mock database resource. This configuration also demonstrates the power of Crossplane to build abstractions called `compositions`, which assemble multiple basic resources into a more complex resource.
 
 Learn more about Composite Resources in the [Crossplane
 Docs](https://docs.crossplane.io/latest/concepts/compositions/).
@@ -56,8 +56,7 @@ kind create cluster
 Enable the Crossplane Helm Chart repository:
 
 ```console
-helm repo add \
-crossplane-stable https://charts.crossplane.io/stable
+helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 ```
 
@@ -91,7 +90,7 @@ kubectl get configurations,configurationrevisions
 
 🎉 Congratulations. You have just installed your first Crossplane-powered platform.
 
-You can now use the control plane to request resources which will simulate getting provisioned in an external cloud service. You do this by creating "claims" against the APIs available on your control palne. Following the example below, create the claims directly:
+You can now use the control plane to request resources which will simulate getting provisioned in an external cloud service. You do this by creating "claims" against the APIs available on your control plane. Following the example below, create the claims directly:
 
 Create a mock database:
 ```console

--- a/apis/XMockDatabase/composition.yaml
+++ b/apis/XMockDatabase/composition.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xmockdatabases.quickstart.crossplane.io
+spec:
+  compositeTypeRef:
+    apiVersion: quickstart.crossplane.io/v1alpha1
+    kind: XMockDatabase
+  mode: Pipeline
+  pipeline:
+    - step: compose
+      functionRef:
+        name: crossplane-contrib-function-kcl
+      input:
+        apiVersion: krm.kcl.dev/v1alpha1
+        kind: KCLRun
+        metadata:
+          name: compose-database
+        spec:
+          target: Resources
+          params:
+            name: "input-instance"
+          source: |
+            oxr = option("params").oxr
+            items = [{
+                apiVersion: "nop.crossplane.io/v1alpha1"
+                kind: "NopResource"
+                metadata.name = oxr.metadata.name
+                spec.forProvider = {
+                  conditionAfter = [{
+                    conditionStatus: "True"
+                    conditionType: "Ready"
+                    time: "5s"
+                  }]
+                  fields = {
+                    instanceClass: oxr.spec.parameters.size
+                    region: oxr.spec.parameters.region
+                    storageGb: oxr.spec.parameters.storage
+                  }
+
+                }
+            }]
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: crossplane-contrib-function-auto-ready

--- a/apis/XMockDatabase/definition.yaml
+++ b/apis/XMockDatabase/definition.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xmockdatabases.quickstart.crossplane.io
+spec:
+  group: quickstart.crossplane.io
+  names:
+    kind: XMockDatabase
+    plural: xmockdatabases
+  claimNames:
+    kind: MockDatabase
+    plural: mockdatabases
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              description: |
+                The specification for how this database should be
+                deployed.
+              properties:
+                parameters:
+                  type: object
+                  description: |
+                    The parameters indicating how this database should
+                    be configured.
+                  properties:
+                    region:
+                      type: string
+                      enum:
+                        - us-east
+                        - us-west
+                      description: |
+                        The geographic region in which this database
+                        should be deployed.
+                    size:
+                      type: string
+                      enum:
+                        - small
+                        - medium
+                        - large
+                      description: |
+                        The machine size for this database.
+                    storage:
+                      type: integer
+                      description: |
+                        The storage size for this database in GB.
+                  required:
+                    - region
+                    - size
+                    - storage
+              required:
+                - parameters

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -17,8 +17,8 @@ spec:
     version: ">=v1.19.0"
   dependsOn:
     - provider: xpkg.upbound.io/crossplane-contrib/provider-nop
-      version: "v0.3.0"
+      version: ">=v0.3.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-kcl
-      version: "v0.11.2"
+      version: ">=v0.11.2"
     - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
-      version: "v0.4.1"
+      version: ">=v0.4.1"

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,0 +1,18 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-quickstart
+  annotations:
+    meta.crossplane.io/maintainer: Upbound <support@upbound.io>
+    meta.crossplane.io/source: github.com/upbound/configuration-quickstart
+    meta.crossplane.io/license: Apache-2.0
+spec:
+  crossplane:
+    version: ">=v1.19.0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-nop
+      version: "v0.3.0"
+    - function: xpkg.upbound.io/crossplane-contrib/function-kcl
+      version: "v0.11.2"
+    - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
+      version: "v0.4.1"

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,3 +1,9 @@
+# This package is manually built/pushed to
+# ghcr.io/crossplane-contrib/configuration-quickstart, with something like:
+# ❯ export CR_PAT=<token>
+# ❯ echo $CR_PAT | docker login ghcr.io -u <user> --password-stdin
+# ❯ crossplane xpkg build -o configuration-quickstart.xpkg
+# ❯ crossplane xpkg push -f configuration-quickstart.xpkg ghcr.io/crossplane-contrib/configuration-quickstart:v0.1.0
 apiVersion: meta.pkg.crossplane.io/v1
 kind: Configuration
 metadata:

--- a/examples/XMockDatabase/example.yaml
+++ b/examples/XMockDatabase/example.yaml
@@ -1,0 +1,9 @@
+apiVersion: platform.acme.co/v1alpha1
+kind: MockDatabase
+metadata:
+  name: database1
+spec:
+  parameters:
+    region: "us-east"
+    size: "small"
+    storage: 10

--- a/examples/XMockDatabase/example.yaml
+++ b/examples/XMockDatabase/example.yaml
@@ -1,4 +1,4 @@
-apiVersion: platform.acme.co/v1alpha1
+apiVersion: quickstart.crossplane.io/v1alpha1
 kind: MockDatabase
 metadata:
   name: database1


### PR DESCRIPTION
This PR adds a single composite, MockDatabse, along with a readme to explain how to use this simple Configuration quickstart.

There's a lingering dependency on packages currently residing in xpkg.upbound.io; we'll need to update this package to use those packages from xpkg.crossplane.io once all maintainers of dependent packages have published to the crossplane-contrib GHCR.